### PR TITLE
60 fix activation password reset pages

### DIFF
--- a/src/login/activateAccountPage.jsx
+++ b/src/login/activateAccountPage.jsx
@@ -1,12 +1,14 @@
 import React from "react";
 import {parse} from "query-string";
+import {withRouter} from "react-router-dom";
 
 import {getCallApi} from "../utils/api/fetchMiddleware";
 import {login} from "./store"
 import {getActivateUserUrl} from "./constants"
 
 
-class activateAccount extends React.Component {
+class ActivateAccount extends React.Component {
+
     constructor() {
         super();
 
@@ -62,4 +64,4 @@ class activateAccount extends React.Component {
     }
 }
 
-export default activateAccount;
+export default withRouter(ActivateAccount);

--- a/src/login/passwordResetPage.jsx
+++ b/src/login/passwordResetPage.jsx
@@ -1,16 +1,17 @@
 import React from "react"
 import {parse} from "query-string";
+import {withRouter} from "react-router-dom";
 
 import PasswordResetForm from "./components/forms/passwordResetForm"
 import OnlyWhenConnectedWrapper from "../utils/login/onlyWhenNotConnectedWrapper"
 import {getPasswordResetUrl} from "./constants"
 
 
-class passwordResetPage extends React.Component {
+class PasswordResetPage extends React.Component {
     constructor() {
         super();
 
-        this.state = {status: "form"};
+        this.state = {status: "form", resetUrl: ''};
 
         this.onPasswordChanged = this.onPasswordChanged.bind(this);
     }
@@ -22,7 +23,7 @@ class passwordResetPage extends React.Component {
         this.code = parsed.code;
 
         if (this.id  && this.code)
-            this.resetUrl = getPasswordResetUrl(this.id, this.code);
+            this.setState({"resetUrl": getPasswordResetUrl(this.id, this.code)});
     }
 
     onPasswordChanged(){
@@ -32,16 +33,16 @@ class passwordResetPage extends React.Component {
     render() {
         let display = "";
         if (this.state.status === "form")
-            display = <PasswordResetForm resetUrl={this.resetUrl} onPasswordChanged={this.onPasswordChanged}/>;
+            display = <PasswordResetForm resetUrl={this.state.resetUrl} onPasswordChanged={this.onPasswordChanged}/>;
         else
             display = "Ton mot de passe a été changé!";
 
         return(
-            <OnlyWhenConnectedWrapper className="passwordResetPage">>
+            <OnlyWhenConnectedWrapper className="passwordResetPage">
                 <h1> Changement de Mot de Passe </h1>
                 {display}
             </OnlyWhenConnectedWrapper>);
     }
 }
 
-export default passwordResetPage
+export default withRouter(PasswordResetPage);

--- a/src/mainLayout/components/menu.jsx
+++ b/src/mainLayout/components/menu.jsx
@@ -32,7 +32,7 @@ const NavBarMobile = ({onToggle, rightItems}) => (
 );
 
 const NavBarDesktop = ({leftItems, rightItems}) => (
-    <Menu fixed="top" inverted>v
+    <Menu fixed="top" inverted>
         <Menu.Item>
             <Link to='/'> <Image src="static/logov3.png" size="small"/></Link>
         </Menu.Item>


### PR DESCRIPTION
# Modifications
## Not directly related
- Update class names to UpperCamelCase
- Removing a typo `>` from the PasswordResetPage
- Removing the typo 'v' from the navbar
## The issue
- Re-include withRouter to components that need to know the location (may not be the best way to do it with react-router v4 but it works)
- Passing the resetUrl of the PasswordResetPage into the state so that it updates properly the child component

closes #60 
closes #43 