### PR TITLE
63 deployment version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,15 @@ Just use `npm install` within the project directory and you're good to go !
 
 The following commands are all defined using npm scripts from the package.json.
 
+The target backend is defined as follows :
+1. Dev setups : The default is `http://localhost:3000` but the value of `API_URL` overrides it.
+2. Prod setup : The env variable `API_URL` has to be set.
+
 If the frontend does not point to a working backend, most of the pages won't work properly.
 
 All the frontend servers are served by default at http://localhost:8000/.
 
 ### Development
-All the deployment servers point to http://localhost:3000/ for the backend.
 
 1. `npm run dev`: Hot-reloading web server for development.
 2. `npm run devStartShotgun`: The same as 1, but modified so that the shotgun
@@ -32,7 +35,6 @@ page is always visible even if the shotgun date is not reached.
 must be used with `npm start` (see below).
 
 #### Production
-All the production servers point to http://www.houlgatefest.fr/api/ for the backend.
 
 1. `npm run build`: Performs a production build to generate the static asset of the website,
 must be used with `npm start` (see below)

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
       "email": "alex.vaast@gmail.com"
     }
   ],
+  "engines": {
+    "node": "12.13.1"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/TanguyLe/HoulgateFest.git"

--- a/package.json
+++ b/package.json
@@ -78,8 +78,8 @@
     "webpack-dev-server": "^3.9.0"
   },
   "scripts": {
-    "dev": "webpack-dev-server --hot --config webpack.dev.config --port 8000",
-    "devStartShotgun": "HAS_STARTED=1 webpack-dev-server --hot --config webpack.dev.config --port 8000",
+    "dev": "API_URL=http://localhost:3000 webpack-dev-server --hot --config webpack.dev.config --port 8000",
+    "devStartShotgun": "API_URL=http://localhost:3000 HAS_STARTED=1 webpack-dev-server --hot --config webpack.dev.config --port 8000",
     "devBuild": "webpack --config webpack.dev.config",
     "build": "webpack --config webpack.prod.config",
     "start": "node server.js"

--- a/package.json
+++ b/package.json
@@ -78,8 +78,8 @@
     "webpack-dev-server": "^3.9.0"
   },
   "scripts": {
-    "dev": "API_URL=http://localhost:3000 webpack-dev-server --hot --config webpack.dev.config --port 8000",
-    "devStartShotgun": "API_URL=http://localhost:3000 HAS_STARTED=1 webpack-dev-server --hot --config webpack.dev.config --port 8000",
+    "dev": "webpack-dev-server --hot --config webpack.dev.config --port 8000",
+    "devStartShotgun": "HAS_STARTED=true webpack-dev-server --hot --config webpack.dev.config --port 8000",
     "devBuild": "webpack --config webpack.dev.config",
     "build": "webpack --config webpack.prod.config",
     "start": "node server.js"

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,2 @@
-// API_URL is defined by webpack
-export const SERVER_ENDPOINT = API_URL;
+export const SERVER_ENDPOINT = process.env.API_URL;
 export const USERS_ENDPOINT = SERVER_ENDPOINT + "/users";

--- a/src/shotgun/shotgunConnectedPage.jsx
+++ b/src/shotgun/shotgunConnectedPage.jsx
@@ -58,7 +58,7 @@ class ShotgunConnectedPage extends React.Component {
             </Message>;
 
         // This is set within webpack
-        if (HAS_STARTED)
+        if (process.env.HAS_STARTED)
             return <ShotgunController/>;
 
         if (this.state.targetDatetime === null)

--- a/src/utils/miscFcts.js
+++ b/src/utils/miscFcts.js
@@ -12,7 +12,7 @@ export const objectMap = (object, mapFn) => {
 };
 
 export const getParisDatetimeFromAPI = async () => {
-    return fetch("http://worldtimeapi.org/api/timezone/Europe/Paris")
+    return fetch("https://worldtimeapi.org/api/timezone/Europe/Paris")
         .then((response) => response.json())
         .catch(error => alert(UNKNOWN_ERROR_MSG + error))
 };

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
     <meta http-equiv="expires" content="-1"/>
     <meta http-equiv="pragma" content="no-cache"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.12/semantic.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.12/semantic.min.css">
     <title>HoulgateFest</title>
 </head>
 <body class="HoulgateFest">

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -1,44 +1,48 @@
 let webpack = require("webpack");
 
 module.exports = {
-        entry: [
-            "react-hot-loader/patch",
-            "./src/houlgatefest.js"
-        ],
-        mode: "development",
-        resolve: {
-            extensions: [".js", ".jsx"],
-            alias: {'react-dom': '@hot-loader/react-dom'}
-        },
-        devtool: "#inline-source-map",
-        module: {
-            rules: [
-                {
-                    test: /\.(jsx|js)?$/,
-                    exclude: [/node_modules/, /bin/],
-                    use: [
-                        "react-hot-loader/webpack",
-                        "babel-loader"
-                    ]
-                },
-                {
-                    test: /\.css$/,
-                    exclude: [/node_modules/, /bin/],
-                    use: ["style-loader", "css-loader"]
-                }
-            ]
-        },
-        output: {
-            path: __dirname + "/web",
-            filename: "houlgatefest.min.js"
-        },
-        devServer: {
-            contentBase: "./web",
-            hot: true,
-            historyApiFallback: true
-        },
-        plugins: [new webpack.HotModuleReplacementPlugin(),
-            new webpack.DefinePlugin({
-                "HAS_STARTED": process.env.HAS_STARTED === '1'
-            })]
+    entry: [
+        "react-hot-loader/patch",
+        "./src/houlgatefest.js"
+    ],
+    mode: "development",
+    resolve: {
+        extensions: [".js", ".jsx"],
+        alias: {'react-dom': '@hot-loader/react-dom'}
+    },
+    devtool: "#inline-source-map",
+    module: {
+        rules: [
+            {
+                test: /\.(jsx|js)?$/,
+                exclude: [/node_modules/, /bin/],
+                use: [
+                    "react-hot-loader/webpack",
+                    "babel-loader"
+                ]
+            },
+            {
+                test: /\.css$/,
+                exclude: [/node_modules/, /bin/],
+                use: ["style-loader", "css-loader"]
+            }
+        ]
+    },
+    output: {
+        path: __dirname + "/web",
+        filename: "houlgatefest.min.js"
+    },
+    devServer: {
+        contentBase: "./web",
+        hot: true,
+        historyApiFallback: true
+    },
+    plugins: [
+        new webpack.HotModuleReplacementPlugin(),
+        new webpack.EnvironmentPlugin({
+            NODE_ENV: "development",
+            API_URL: "http://localhost:3000",
+            HAS_STARTED: false
+        })
+    ]
 };

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -39,7 +39,6 @@ module.exports = {
         },
         plugins: [new webpack.HotModuleReplacementPlugin(),
             new webpack.DefinePlugin({
-                "API_URL": "\"http://localhost:3000\"",
                 "HAS_STARTED": process.env.HAS_STARTED === '1'
             })]
 };

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -5,7 +5,6 @@ const TerserPlugin = require('terser-webpack-plugin');
 
 module.exports = {
     entry: [
-        "react-hot-loader/patch",
         "./src/houlgatefest.js"
     ],
     mode: "production",
@@ -39,7 +38,6 @@ module.exports = {
             "process.env": {
                 NODE_ENV: JSON.stringify("production")
             },
-            "API_URL": "\"http://houlgatefest.fr/api\"",
             "HAS_STARTED": false
         })
     ]

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -34,11 +34,10 @@ module.exports = {
         minimizer: [new TerserPlugin()],
     },
     plugins: [
-        new webpack.DefinePlugin({
-            "process.env": {
-                NODE_ENV: JSON.stringify("production")
-            },
-            "HAS_STARTED": false
+        new webpack.EnvironmentPlugin({
+            NODE_ENV: "production",
+            API_URL: null,
+            HAS_STARTED: false
         })
     ]
 };


### PR DESCRIPTION
# Goal
Making the front deployment ready for heroku
# Modifications
- Add the engine to the package.json
- Switch to env variables for API_URL and HAS_STARTED. They're sill handled by webpack
- Switching semantic ui url and worldtimeapi to https instead of http
- Using NODE_ENV properly "production" vs "deployment"
- Setting API_URL by default at localhost 3000 on dev and without a default in prod