### PR TITLE
Updating scoreboard address for 2021 in webpack en vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - The shotgun popup display is now flowing [PR97](https://github.com/TanguyLe/HoulgateFestFront/pull/97)
-- The scoreboard url now points ot the 2021 scoreboard [MR103](https://github.com/TanguyLe/HoulgateFestFront/pull/103)
+- The scoreboard url now points ot the 2021 scoreboard [PR103](https://github.com/TanguyLe/HoulgateFestFront/pull/103)
+- Node engine updated for vercel [PR103](https://github.com/TanguyLe/HoulgateFestFront/pull/103)
 
 
 ## [v0.3.0] 2020-09-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - The shotgun popup display is now flowing [PR97](https://github.com/TanguyLe/HoulgateFestFront/pull/97)
+- The scoreboard url now points ot the 2021 scoreboard [MR103](https://github.com/TanguyLe/HoulgateFestFront/pull/103)
 
 
 ## [v0.3.0] 2020-09-19

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     }
   ],
   "engines": {
-    "node": "12.18.3"
+    "node": "12.20.1"
   },
   "repository": {
     "type": "git",

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -43,7 +43,7 @@ module.exports = {
             NODE_ENV: "development",
             API_URL: "http://localhost:3000",
             HAS_STARTED: false,
-            SCORES_BOARD_URL: "https://keepthescore.co/board/wytbkwbpzjr/"
+            SCORES_BOARD_URL: "https://keepthescore.co/board/kecveeapsar/"
         })
     ]
 };

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -38,7 +38,7 @@ module.exports = {
             NODE_ENV: "production",
             API_URL: null,
             HAS_STARTED: false,
-            SCORES_BOARD_URL: "https://keepthescore.co/board/wytbkwbpzjr/"
+            SCORES_BOARD_URL: "https://keepthescore.co/board/kecveeapsar/"
         })
     ]
 };


### PR DESCRIPTION
# Goal
Update the scoreboard to 2021 scoreboard
# Modifications
- Change the scoreboard url in the webpack prod config
- Change the scoreboard url in the webpack dev config

- [x] Add a line in the changelog referring to this merge request